### PR TITLE
fix(OrderDocuments): unexpected end of file error

### DIFF
--- a/Controllers/Api/SwagMigrationOrderDocuments.php
+++ b/Controllers/Api/SwagMigrationOrderDocuments.php
@@ -77,6 +77,10 @@ class Shopware_Controllers_Api_SwagMigrationOrderDocuments extends Shopware_Cont
             $upstream = $documentService->readFile($filePath);
             $downstream = \fopen('php://output', 'rb');
             \stream_copy_to_stream($upstream, $downstream);
+
+            fclose($downstream);
+            fclose($upstream);
+            exit;
         } else {
             // Disable Smarty rendering
             $this->Front()->Plugins()->ViewRenderer()->setNoRender();

--- a/Controllers/Api/SwagMigrationOrderDocuments.php
+++ b/Controllers/Api/SwagMigrationOrderDocuments.php
@@ -80,7 +80,7 @@ class Shopware_Controllers_Api_SwagMigrationOrderDocuments extends Shopware_Cont
 
             fclose($downstream);
             fclose($upstream);
-            exit;
+            $this->closeResponse();
         } else {
             // Disable Smarty rendering
             $this->Front()->Plugins()->ViewRenderer()->setNoRender();
@@ -89,6 +89,7 @@ class Shopware_Controllers_Api_SwagMigrationOrderDocuments extends Shopware_Cont
             $this->setDownloadHeaders($filePath, $orderNumber);
 
             \readfile($filePath);
+            $this->closeResponse();
         }
     }
 
@@ -108,6 +109,16 @@ class Shopware_Controllers_Api_SwagMigrationOrderDocuments extends Shopware_Cont
         $response->setHeader('Content-Transfer-Encoding', 'binary');
         $response->setHeader('Content-Length', $documentService->getFileSize($filePath));
         $response->sendHeaders();
-        $response->sendResponse();
+    }
+
+    /*
+     * Taken from \Symfony\Component\HttpFoundation\Response::send
+     */
+    private function closeResponse() {
+        if (function_exists('fastcgi_finish_request')) {
+            fastcgi_finish_request();
+        } elseif ('cli' !== PHP_SAPI) {
+            static::closeOutputBuffers(0, true);
+        }
     }
 }


### PR DESCRIPTION
When I did a migration via an API connection I got a lot of these errors:

code: `SWAG_MIGRATION_CANNOT_GET_ORDER_DOCUMENT_FILE`
title: `The order_document file cannot be downloaded / copied`
description: `The order_document file with the uri "d52cab79febe9c5d638108cfdbbc878e" and media id "c3f75ba2255d4f48b1007b3a1b57d19f" cannot be downloaded / copied.`

While tracing down this bug I found out it's related to this SW5 plugin. I could also reproduce this in Postman, after loading for a bit more than 30 seconds I got an `Unexpected end of file error`.

Adding these lines fixed the error for me.

Taken from https://stackoverflow.com/a/37083835/4303873