### PR TITLE
fix: include id in product seo main categories

### DIFF
--- a/Repository/ProductRepository.php
+++ b/Repository/ProductRepository.php
@@ -286,7 +286,7 @@ class ProductRepository extends AbstractRepository
     {
         // Just select subshop main categories and ignore language shops
         $query = $this->connection->createQueryBuilder();
-        $query->select(['seoCategory.article_id', 'seoCategory.shop_id as shopId', 'seoCategory.category_id as categoryId'])
+        $query->select(['seoCategory.article_id', 'seoCategory.id', 'seoCategory.shop_id as shopId', 'seoCategory.category_id as categoryId'])
             ->from('s_articles_categories_seo', 'seoCategory')
             ->join('seoCategory', 's_core_shops', 'shop', 'shop.id = seoCategory.shop_id')
             ->where('article_id IN (:ids)')

--- a/Tests/Functional/Service/ProductServiceTest.php
+++ b/Tests/Functional/Service/ProductServiceTest.php
@@ -176,15 +176,19 @@ class ProductServiceTest extends TestCase
 
         $productOne = $this->getProductById($products, '9');
         static::assertCount(2, $productOne['mainCategories']);
+        static::assertSame('6', $productOne['mainCategories'][0]['id']);
         static::assertSame('1', $productOne['mainCategories'][0]['shopId']);
         static::assertSame('14', $productOne['mainCategories'][0]['categoryId']);
+        static::assertSame('8', $productOne['mainCategories'][1]['id']);
         static::assertSame('3', $productOne['mainCategories'][1]['shopId']);
         static::assertSame('34', $productOne['mainCategories'][1]['categoryId']);
 
         $productTwo = $this->getProductById($products, '272');
         static::assertCount(2, $productTwo['mainCategories']);
+        static::assertSame('3', $productTwo['mainCategories'][0]['id']);
         static::assertSame('1', $productTwo['mainCategories'][0]['shopId']);
         static::assertSame('15', $productTwo['mainCategories'][0]['categoryId']);
+        static::assertSame('5', $productTwo['mainCategories'][1]['id']);
         static::assertSame('3', $productTwo['mainCategories'][1]['shopId']);
         static::assertSame('16', $productTwo['mainCategories'][1]['categoryId']);
     }

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,10 +21,12 @@
 
     <changelog version="2.2.0">
         <changes lang="de">
-            #13670 - Die Umgebungsinformationen wurden angepasst, um einige Konfigurationswerte zurückzugeben, die die SW5-Installation eindeutig identifizieren. SW6 verwendet diese, um davor zu warnen, mehr als einmal Verbindungen zum selben Quellsystem herzustellen.
+            #13670 - Die Umgebungsinformationen wurden angepasst, um einige Konfigurationswerte zurückzugeben, die die SW5-Installation eindeutig identifizieren. SW6 verwendet diese, um davor zu warnen, mehr als einmal Verbindungen zum selben Quellsystem herzustellen;
+            #14517 - ID zu den SEO-Hauptkategorien von Produkten hinzugefügt, um stabile Zuordnung zu ermöglichen;
         </changes>
         <changes lang="en">
-            #13670 - Adjusted environment information to return some configuration values, that uniquely identify the SW5 installation. SW6 uses that to warn against creating connections to the same source system more than once
+            #13670 - Adjusted environment information to return some configuration values, that uniquely identify the SW5 installation. SW6 uses that to warn against creating connections to the same source system more than once;
+            #14517 - Added ID to product SEO main categories to enable stable mapping;
         </changes>
     </changelog>
 


### PR DESCRIPTION
part of shopware/SwagMigrationAssistant#125

Adds `seoCategory.id` to the product SEO main categories query, enabling the migration assistant to use stable IDs for `main_category` mapping.