### PR TITLE
fix: customer.language maps to shopId, not localeId - adding correct association

### DIFF
--- a/Repository/CustomerRepository.php
+++ b/Repository/CustomerRepository.php
@@ -59,11 +59,29 @@ class CustomerRepository extends AbstractRepository
         $query->leftJoin('defaultpayment', 's_core_paymentmeans_attributes', 'defaultpayment_attributes', 'defaultpayment.id = defaultpayment_attributes.paymentmeanID');
         $this->addTableSelection($query, 's_core_paymentmeans_attributes', 'defaultpayment_attributes');
 
-        $query->leftJoin('customer', 's_core_locales', 'customerlanguage', 'customer.language = customerlanguage.id');
-        $this->addTableSelection($query, 's_core_locales', 'customerlanguage');
-
-        $query->leftJoin('customer', 's_core_shops', 'shop', 'customer.subshopID = shop.id');
+        $query->leftJoin(
+            'customer',
+            's_core_shops',
+            'shop',
+            'customer.subshopID = shop.id'
+        );
         $this->addTableSelection($query, 's_core_shops', 'shop');
+
+        // customer.language maps to the shopID and not the localeID
+        $query->leftJoin(
+            'customer',
+            's_core_shops',
+            'customerlanguageshop',
+            'customer.language = customerlanguageshop.id'
+        );
+        
+        $query->leftJoin(
+            'customer',
+            's_core_locales',
+            'customerlanguage',
+            'customerlanguage.id = COALESCE(customerlanguageshop.locale_id, shop.locale_id, customer.language)'
+        );
+        $this->addTableSelection($query, 's_core_locales', 'customerlanguage');
 
         $query->where('customer.id IN (:ids)');
         $query->setParameter('ids', $ids, Connection::PARAM_STR_ARRAY);

--- a/Repository/CustomerRepository.php
+++ b/Repository/CustomerRepository.php
@@ -79,7 +79,7 @@ class CustomerRepository extends AbstractRepository
             'customer',
             's_core_locales',
             'customerlanguage',
-            'customerlanguage.id = COALESCE(customerlanguageshop.locale_id, shop.locale_id, customer.language)'
+            'customerlanguage.id = customerlanguageshop.locale_id'
         );
         $this->addTableSelection($query, 's_core_locales', 'customerlanguage');
 

--- a/Repository/CustomerRepository.php
+++ b/Repository/CustomerRepository.php
@@ -67,14 +67,15 @@ class CustomerRepository extends AbstractRepository
         );
         $this->addTableSelection($query, 's_core_shops', 'shop');
 
-        // customer.language maps to the shopID and not the localeID
+        // customer.language maps to the shopID and not directly to the localeID
+        // so we need to join the shop table to get the localeID and then join the locale table to get the locale code
         $query->leftJoin(
             'customer',
             's_core_shops',
             'customerlanguageshop',
             'customer.language = customerlanguageshop.id'
         );
-        
+
         $query->leftJoin(
             'customer',
             's_core_locales',

--- a/Service/LanguageService.php
+++ b/Service/LanguageService.php
@@ -87,8 +87,25 @@ class LanguageService
     {
         $query = $this->connection->createQueryBuilder();
         $query->from('s_user', 'customer');
-        $query->addSelect('DISTINCT customer.language');
+        $query->leftJoin(
+            'customer',
+            's_core_shops',
+            'customerlanguageshop',
+            'customer.language = customerlanguageshop.id'
+        );
+
+        $query->leftJoin(
+            'customerlanguageshop',
+            's_core_locales',
+            'customerlocales',
+            'customerlanguageshop.locale_id = customerlocales.id'
+        );
+    
+        $query->addSelect('customerlocales.id');
+        $query->distinct();
         $query->where('customer.language IS NOT NULL');
+        $query->andWhere('customerlanguageshop.locale_id IS NOT NULL');
+        $query->andWhere('customerlocales.id IS NOT NULL');
 
         return $query->execute()->fetchAll(\PDO::FETCH_COLUMN);
     }

--- a/Service/LanguageService.php
+++ b/Service/LanguageService.php
@@ -87,6 +87,9 @@ class LanguageService
     {
         $query = $this->connection->createQueryBuilder();
         $query->from('s_user', 'customer');
+
+        // customer.language maps to the shopID and not directly to the localeID
+        // so we need to join the shop table to get the localeID and then join the locale table to get the locale code
         $query->leftJoin(
             'customer',
             's_core_shops',
@@ -100,7 +103,7 @@ class LanguageService
             'customerlocales',
             'customerlanguageshop.locale_id = customerlocales.id'
         );
-    
+
         $query->addSelect('customerlocales.id');
         $query->distinct();
         $query->where('customer.language IS NOT NULL');

--- a/Service/LanguageService.php
+++ b/Service/LanguageService.php
@@ -104,8 +104,7 @@ class LanguageService
             'customerlanguageshop.locale_id = customerlocales.id'
         );
 
-        $query->addSelect('customerlocales.id');
-        $query->distinct();
+        $query->addSelect('DISTINCT customerlocales.id');
         $query->where('customer.language IS NOT NULL');
         $query->andWhere('customerlanguageshop.locale_id IS NOT NULL');
         $query->andWhere('customerlocales.id IS NOT NULL');

--- a/Tests/Functional/Repository/CustomerRepositoryTest.php
+++ b/Tests/Functional/Repository/CustomerRepositoryTest.php
@@ -55,12 +55,13 @@ class CustomerRepositoryTest extends TestCase
      */
     public function testFetchResolvesCustomerLanguageThroughShopLocale()
     {
+        $offset = (int) $this->connection->fetchColumn('SELECT COUNT(*) FROM s_user');
         $sql = file_get_contents(__DIR__ . '/_fixtures/customer.sql');
         static::assertTrue(\is_string($sql));
 
         $this->connection->executeQuery($sql);
 
-        $customer = $this->getCustomerRepository()->fetch()[0];
+        $customer = $this->getCustomerRepository()->fetch($offset, 1)[0];
         $expectedLocaleId = (string) $this->connection->fetchColumn('SELECT locale_id FROM s_core_shops WHERE id = 3');
 
         static::assertSame('3', $customer['customer.id']);

--- a/Tests/Functional/Repository/CustomerRepositoryTest.php
+++ b/Tests/Functional/Repository/CustomerRepositoryTest.php
@@ -51,6 +51,48 @@ class CustomerRepositoryTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testFetchResolvesCustomerLanguageThroughShopLocale()
+    {
+        $shopId = (int) $this->connection->fetchColumn(
+            'SELECT GREATEST((SELECT COALESCE(MAX(id), 0) FROM s_core_shops), (SELECT COALESCE(MAX(id), 0) FROM s_core_locales)) + 1'
+        );
+        $localeId = $shopId + 1;
+        $customerId = $this->connection->fetchColumn('SELECT id FROM s_user ORDER BY id ASC LIMIT 1');
+
+        static::assertTrue($customerId !== false);
+
+        $this->connection->insert('s_core_locales', [
+            'id' => $shopId,
+            'locale' => 'yy_YY',
+            'language' => 'Decoy language',
+            'territory' => 'Decoy territory',
+        ]);
+
+        $this->connection->insert('s_core_locales', [
+            'id' => $localeId,
+            'locale' => 'zz_ZZ',
+            'language' => 'Test language',
+            'territory' => 'Test territory',
+        ]);
+
+        $this->createShopWithLocale($shopId, $localeId);
+
+        $this->connection->update(
+            's_user',
+            ['language' => (string) $shopId],
+            ['id' => (int) $customerId]
+        );
+
+        $customer = $this->findCustomerById($this->getCustomerRepository()->fetch(), (int) $customerId);
+
+        static::assertTrue(\is_array($customer));
+        static::assertSame('zz_ZZ', $customer['customerlanguage.locale']);
+        static::assertNotSame('yy_YY', $customer['customerlanguage.locale']);
+    }
+
+    /**
      * @before
      *
      * @return void
@@ -66,5 +108,39 @@ class CustomerRepositoryTest extends TestCase
     private function getCustomerRepository()
     {
         return new CustomerRepository($this->connection);
+    }
+
+    /**
+     * @return void
+     */
+    private function createShopWithLocale($shopId, $localeId)
+    {
+        $shop = $this->connection->fetchAssoc('SELECT * FROM s_core_shops ORDER BY id ASC LIMIT 1');
+
+        static::assertTrue(\is_array($shop));
+
+        $shop['id'] = $shopId;
+        $shop['name'] = 'locale-test-' . $shopId;
+        $shop['title'] = 'Locale Test ' . $shopId;
+        $shop['host'] = 'locale-test-' . $shopId . '.example.com';
+        $shop['locale_id'] = $localeId;
+        $shop['default'] = 0;
+        $shop['active'] = 1;
+
+        $this->connection->insert('s_core_shops', $shop);
+    }
+
+    /**
+     * @return array|null
+     */
+    private function findCustomerById(array $customers, $customerId)
+    {
+        foreach ($customers as $customer) {
+            if ((int) $customer['customer.id'] === $customerId) {
+                return $customer;
+            }
+        }
+
+        return null;
     }
 }

--- a/Tests/Functional/Repository/CustomerRepositoryTest.php
+++ b/Tests/Functional/Repository/CustomerRepositoryTest.php
@@ -58,16 +58,26 @@ class CustomerRepositoryTest extends TestCase
         $shop = $this->connection->fetchAssoc(
             'SELECT id, locale_id
              FROM s_core_shops
-             WHERE locale_id <> id
+             WHERE locale_id IS NOT NULL
              ORDER BY id ASC
              LIMIT 1'
+        );
+        $alternateLocaleId = $this->connection->fetchColumn(
+            'SELECT id
+             FROM s_core_locales
+             WHERE id <> ?
+             ORDER BY id ASC
+             LIMIT 1',
+            [(int) $shop['id']]
         );
         $offset = (int) $this->connection->fetchColumn('SELECT COUNT(*) FROM s_user');
         $sql = file_get_contents(__DIR__ . '/_fixtures/customer.sql');
 
         static::assertTrue(\is_array($shop));
+        static::assertTrue($alternateLocaleId !== false);
         static::assertTrue(\is_string($sql));
 
+        $this->connection->update('s_core_shops', ['locale_id' => (int) $alternateLocaleId], ['id' => (int) $shop['id']]);
         $this->connection->executeQuery($sql);
         $this->connection->update('s_user', ['language' => (string) $shop['id']], ['id' => 3]);
 
@@ -75,8 +85,8 @@ class CustomerRepositoryTest extends TestCase
 
         static::assertSame('3', $customer['customer.id']);
         static::assertSame((string) $shop['id'], $customer['customer.language']);
-        static::assertNotSame($customer['customer.language'], (string) $shop['locale_id']);
-        static::assertSame((string) $shop['locale_id'], $customer['customerlanguage.id']);
+        static::assertNotSame($customer['customer.language'], (string) $alternateLocaleId);
+        static::assertSame((string) $alternateLocaleId, $customer['customerlanguage.id']);
     }
 
     /**

--- a/Tests/Functional/Repository/CustomerRepositoryTest.php
+++ b/Tests/Functional/Repository/CustomerRepositoryTest.php
@@ -77,8 +77,13 @@ class CustomerRepositoryTest extends TestCase
         static::assertTrue($alternateLocaleId !== false);
         static::assertTrue(\is_string($sql));
 
+        // Force a mismatch between the shop id and its locale id so the repository
+        // must resolve customer.language through the shop relation, not directly as a locale id.
         $this->connection->update('s_core_shops', ['locale_id' => (int) $alternateLocaleId], ['id' => (int) $shop['id']]);
         $this->connection->executeQuery($sql);
+
+        // Point the fixture customer at that shop id. The repository should then expose
+        // the shop's locale_id as customerlanguage.id.
         $this->connection->update('s_user', ['language' => (string) $shop['id']], ['id' => 3]);
 
         $customer = $this->getCustomerRepository()->fetch($offset, 1)[0];

--- a/Tests/Functional/Repository/CustomerRepositoryTest.php
+++ b/Tests/Functional/Repository/CustomerRepositoryTest.php
@@ -62,6 +62,8 @@ class CustomerRepositoryTest extends TestCase
              ORDER BY id ASC
              LIMIT 1'
         );
+        static::assertTrue(\is_array($shop));
+
         $alternateLocaleId = $this->connection->fetchColumn(
             'SELECT id
              FROM s_core_locales
@@ -73,7 +75,6 @@ class CustomerRepositoryTest extends TestCase
         $offset = (int) $this->connection->fetchColumn('SELECT COUNT(*) FROM s_user');
         $sql = file_get_contents(__DIR__ . '/_fixtures/customer.sql');
 
-        static::assertTrue(\is_array($shop));
         static::assertTrue($alternateLocaleId !== false);
         static::assertTrue(\is_string($sql));
 

--- a/Tests/Functional/Repository/CustomerRepositoryTest.php
+++ b/Tests/Functional/Repository/CustomerRepositoryTest.php
@@ -55,41 +55,18 @@ class CustomerRepositoryTest extends TestCase
      */
     public function testFetchResolvesCustomerLanguageThroughShopLocale()
     {
-        $shopId = (int) $this->connection->fetchColumn(
-            'SELECT GREATEST((SELECT COALESCE(MAX(id), 0) FROM s_core_shops), (SELECT COALESCE(MAX(id), 0) FROM s_core_locales)) + 1'
-        );
-        $localeId = $shopId + 1;
-        $customerId = $this->connection->fetchColumn('SELECT id FROM s_user ORDER BY id ASC LIMIT 1');
+        $sql = file_get_contents(__DIR__ . '/_fixtures/customer.sql');
+        static::assertTrue(\is_string($sql));
 
-        static::assertTrue($customerId !== false);
+        $this->connection->executeQuery($sql);
 
-        $this->connection->insert('s_core_locales', [
-            'id' => $shopId,
-            'locale' => 'yy_YY',
-            'language' => 'Decoy language',
-            'territory' => 'Decoy territory',
-        ]);
+        $customer = $this->getCustomerRepository()->fetch()[0];
+        $expectedLocaleId = (string) $this->connection->fetchColumn('SELECT locale_id FROM s_core_shops WHERE id = 3');
 
-        $this->connection->insert('s_core_locales', [
-            'id' => $localeId,
-            'locale' => 'zz_ZZ',
-            'language' => 'Test language',
-            'territory' => 'Test territory',
-        ]);
-
-        $this->createShopWithLocale($shopId, $localeId);
-
-        $this->connection->update(
-            's_user',
-            ['language' => (string) $shopId],
-            ['id' => (int) $customerId]
-        );
-
-        $customer = $this->findCustomerById($this->getCustomerRepository()->fetch(), (int) $customerId);
-
-        static::assertTrue(\is_array($customer));
-        static::assertSame('zz_ZZ', $customer['customerlanguage.locale']);
-        static::assertNotSame('yy_YY', $customer['customerlanguage.locale']);
+        static::assertSame('3', $customer['customer.id']);
+        static::assertSame('3', $customer['customer.language']);
+        static::assertNotSame($customer['customer.language'], $expectedLocaleId);
+        static::assertSame($expectedLocaleId, $customer['customerlanguage.id']);
     }
 
     /**
@@ -108,39 +85,5 @@ class CustomerRepositoryTest extends TestCase
     private function getCustomerRepository()
     {
         return new CustomerRepository($this->connection);
-    }
-
-    /**
-     * @return void
-     */
-    private function createShopWithLocale($shopId, $localeId)
-    {
-        $shop = $this->connection->fetchAssoc('SELECT * FROM s_core_shops ORDER BY id ASC LIMIT 1');
-
-        static::assertTrue(\is_array($shop));
-
-        $shop['id'] = $shopId;
-        $shop['name'] = 'locale-test-' . $shopId;
-        $shop['title'] = 'Locale Test ' . $shopId;
-        $shop['host'] = 'locale-test-' . $shopId . '.example.com';
-        $shop['locale_id'] = $localeId;
-        $shop['default'] = 0;
-        $shop['active'] = 1;
-
-        $this->connection->insert('s_core_shops', $shop);
-    }
-
-    /**
-     * @return array|null
-     */
-    private function findCustomerById(array $customers, $customerId)
-    {
-        foreach ($customers as $customer) {
-            if ((int) $customer['customer.id'] === $customerId) {
-                return $customer;
-            }
-        }
-
-        return null;
     }
 }

--- a/Tests/Functional/Repository/CustomerRepositoryTest.php
+++ b/Tests/Functional/Repository/CustomerRepositoryTest.php
@@ -55,19 +55,28 @@ class CustomerRepositoryTest extends TestCase
      */
     public function testFetchResolvesCustomerLanguageThroughShopLocale()
     {
+        $shop = $this->connection->fetchAssoc(
+            'SELECT id, locale_id
+             FROM s_core_shops
+             WHERE locale_id <> id
+             ORDER BY id ASC
+             LIMIT 1'
+        );
         $offset = (int) $this->connection->fetchColumn('SELECT COUNT(*) FROM s_user');
         $sql = file_get_contents(__DIR__ . '/_fixtures/customer.sql');
+
+        static::assertTrue(\is_array($shop));
         static::assertTrue(\is_string($sql));
 
         $this->connection->executeQuery($sql);
+        $this->connection->update('s_user', ['language' => (string) $shop['id']], ['id' => 3]);
 
         $customer = $this->getCustomerRepository()->fetch($offset, 1)[0];
-        $expectedLocaleId = (string) $this->connection->fetchColumn('SELECT locale_id FROM s_core_shops WHERE id = 3');
 
         static::assertSame('3', $customer['customer.id']);
-        static::assertSame('3', $customer['customer.language']);
-        static::assertNotSame($customer['customer.language'], $expectedLocaleId);
-        static::assertSame($expectedLocaleId, $customer['customerlanguage.id']);
+        static::assertSame((string) $shop['id'], $customer['customer.language']);
+        static::assertNotSame($customer['customer.language'], (string) $shop['locale_id']);
+        static::assertSame((string) $shop['locale_id'], $customer['customerlanguage.id']);
     }
 
     /**

--- a/Tests/Functional/Service/LanguageServiceTest.php
+++ b/Tests/Functional/Service/LanguageServiceTest.php
@@ -34,13 +34,27 @@ class LanguageServiceTest extends TestCase
 
         static::assertGreaterThan(0, $shopId);
 
-        $this->connection->executeStatement(
-            'INSERT INTO s_core_locales (id, locale, language, territory)
-             VALUES (?, ?, ?, ?)
-             ON DUPLICATE KEY UPDATE locale = VALUES(locale), language = VALUES(language), territory = VALUES(territory)',
-            [$shopId, 'yy_YY', 'Decoy language', 'Decoy territory']
-        );
+        // If the implementation wrongly treats customer.language as a locale id,
+        // it would resolve this decoy locale instead of going through the shop.
+        if ($this->connection->fetchColumn('SELECT id FROM s_core_locales WHERE id = ?', [$shopId]) !== false) {
+            $this->connection->update('s_core_locales', [
+                'locale' => 'yy_YY',
+                'language' => 'Decoy language',
+                'territory' => 'Decoy territory',
+            ], [
+                'id' => $shopId,
+            ]);
+        } else {
+            $this->connection->insert('s_core_locales', [
+                'id' => $shopId,
+                'locale' => 'yy_YY',
+                'language' => 'Decoy language',
+                'territory' => 'Decoy territory',
+            ]);
+        }
 
+        // This is the locale the service should return after resolving customer.language
+        // through shop.id -> shop.locale_id.
         $this->connection->insert('s_core_locales', [
             'id' => $localeId,
             'locale' => 'zz_ZZ',

--- a/Tests/Functional/Service/LanguageServiceTest.php
+++ b/Tests/Functional/Service/LanguageServiceTest.php
@@ -25,20 +25,21 @@ class LanguageServiceTest extends TestCase
      */
     public function testReadResolvesCustomerLanguageThroughShopLocale()
     {
-        $shopId = (int) $this->connection->fetchColumn(
-            'SELECT GREATEST((SELECT COALESCE(MAX(id), 0) FROM s_core_shops), (SELECT COALESCE(MAX(id), 0) FROM s_core_locales)) + 1'
-        );
-        $localeId = $shopId + 1;
-        $customerId = $this->connection->fetchColumn('SELECT id FROM s_user ORDER BY id ASC LIMIT 1');
+        $customerId = $this->connection->fetchColumn('SELECT id FROM s_user WHERE language IS NOT NULL ORDER BY id ASC LIMIT 1');
+        $localeId = (int) $this->connection->fetchColumn('SELECT COALESCE(MAX(id), 0) + 1 FROM s_core_locales');
 
         static::assertTrue($customerId !== false);
 
-        $this->connection->insert('s_core_locales', [
-            'id' => $shopId,
-            'locale' => 'yy_YY',
-            'language' => 'Decoy language',
-            'territory' => 'Decoy territory',
-        ]);
+        $shopId = (int) $this->connection->fetchColumn('SELECT language FROM s_user WHERE id = ?', [(int) $customerId]);
+
+        static::assertGreaterThan(0, $shopId);
+
+        $this->connection->executeStatement(
+            'INSERT INTO s_core_locales (id, locale, language, territory)
+             VALUES (?, ?, ?, ?)
+             ON DUPLICATE KEY UPDATE locale = VALUES(locale), language = VALUES(language), territory = VALUES(territory)',
+            [$shopId, 'yy_YY', 'Decoy language', 'Decoy territory']
+        );
 
         $this->connection->insert('s_core_locales', [
             'id' => $localeId,
@@ -47,13 +48,7 @@ class LanguageServiceTest extends TestCase
             'territory' => 'Test territory',
         ]);
 
-        $this->createShopWithLocale($shopId, $localeId);
-
-        $this->connection->update(
-            's_user',
-            ['language' => (string) $shopId],
-            ['id' => (int) $customerId]
-        );
+        static::assertSame(1, $this->connection->update('s_core_shops', ['locale_id' => $localeId], ['id' => $shopId]));
 
         $languageService = $this->getContainer()->get('swag_migration_connector.service.language_service');
         $languages = $languageService->getLanguages();
@@ -71,25 +66,5 @@ class LanguageServiceTest extends TestCase
     protected function setUpMethod()
     {
         $this->connection = $this->getContainer()->get('dbal_connection');
-    }
-
-    /**
-     * @return void
-     */
-    private function createShopWithLocale($shopId, $localeId)
-    {
-        $shop = $this->connection->fetchAssoc('SELECT * FROM s_core_shops ORDER BY id ASC LIMIT 1');
-
-        static::assertTrue(\is_array($shop));
-
-        $shop['id'] = $shopId;
-        $shop['name'] = 'locale-test-' . $shopId;
-        $shop['title'] = 'Locale Test ' . $shopId;
-        $shop['host'] = 'locale-test-' . $shopId . '.example.com';
-        $shop['locale_id'] = $localeId;
-        $shop['default'] = 0;
-        $shop['active'] = 1;
-
-        $this->connection->insert('s_core_shops', $shop);
     }
 }

--- a/Tests/Functional/Service/LanguageServiceTest.php
+++ b/Tests/Functional/Service/LanguageServiceTest.php
@@ -23,12 +23,22 @@ class LanguageServiceTest extends TestCase
     /**
      * @return void
      */
-    public function testReadIncludesCustomerLocalesOutsideShopLocales()
+    public function testReadResolvesCustomerLanguageThroughShopLocale()
     {
-        $localeId = (int) $this->connection->fetchColumn('SELECT COALESCE(MAX(id), 0) + 1 FROM s_core_locales');
+        $shopId = (int) $this->connection->fetchColumn(
+            'SELECT GREATEST((SELECT COALESCE(MAX(id), 0) FROM s_core_shops), (SELECT COALESCE(MAX(id), 0) FROM s_core_locales)) + 1'
+        );
+        $localeId = $shopId + 1;
         $customerId = $this->connection->fetchColumn('SELECT id FROM s_user ORDER BY id ASC LIMIT 1');
 
         static::assertTrue($customerId !== false);
+
+        $this->connection->insert('s_core_locales', [
+            'id' => $shopId,
+            'locale' => 'yy_YY',
+            'language' => 'Decoy language',
+            'territory' => 'Decoy territory',
+        ]);
 
         $this->connection->insert('s_core_locales', [
             'id' => $localeId,
@@ -37,16 +47,20 @@ class LanguageServiceTest extends TestCase
             'territory' => 'Test territory',
         ]);
 
+        $this->createShopWithLocale($shopId, $localeId);
+
         $this->connection->update(
             's_user',
-            ['language' => (string) $localeId],
+            ['language' => (string) $shopId],
             ['id' => (int) $customerId]
         );
 
         $languageService = $this->getContainer()->get('swag_migration_connector.service.language_service');
         $languages = $languageService->getLanguages();
+        $locales = \array_column($languages, 'locale');
 
-        static::assertContains('zz-ZZ', \array_column($languages, 'locale'));
+        static::assertContains('zz-ZZ', $locales);
+        static::assertNotContains('yy-YY', $locales);
     }
 
     /**
@@ -57,5 +71,25 @@ class LanguageServiceTest extends TestCase
     protected function setUpMethod()
     {
         $this->connection = $this->getContainer()->get('dbal_connection');
+    }
+
+    /**
+     * @return void
+     */
+    private function createShopWithLocale($shopId, $localeId)
+    {
+        $shop = $this->connection->fetchAssoc('SELECT * FROM s_core_shops ORDER BY id ASC LIMIT 1');
+
+        static::assertTrue(\is_array($shop));
+
+        $shop['id'] = $shopId;
+        $shop['name'] = 'locale-test-' . $shopId;
+        $shop['title'] = 'Locale Test ' . $shopId;
+        $shop['host'] = 'locale-test-' . $shopId . '.example.com';
+        $shop['locale_id'] = $localeId;
+        $shop['default'] = 0;
+        $shop['active'] = 1;
+
+        $this->connection->insert('s_core_shops', $shop);
     }
 }


### PR DESCRIPTION
when migrating, unnecessary / unused languages are created. this is due to the mapping of customer.language which maps to the shopid and not the localeid.

this causes SWAG_MIGRATION_WRITE_EXCEPTION errors, because it assigns a wrong language id to the customer, so the customer cant be created and their order neither as well.

[/languageId] The language "019e88ab8071730686a04a88ca695f99" is not assigned to the sales channel. in /var/www/vhosts/c8yb4.creoline.cloud/httpdocs/vendor/shopware/core/Framework/DataAbstractionLayer/Write/WriteContext.php:46
Converted data (JSON):

/**

Id of the language sub shop
[var](https://github.com/var) string
[Orm](https://github.com/Orm)\Column(name="language", type="string", length=10, nullable=false)
*/
private $languageId = '1';